### PR TITLE
Fix issue by falling back to window.innerWidth.

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,4 +5,4 @@
  */
 
 // You can delete this file if you're not using it
-// import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap/dist/css/bootstrap.min.css'

--- a/src/components/Layout/Footer/GlobalFooter.global.scss
+++ b/src/components/Layout/Footer/GlobalFooter.global.scss
@@ -1,5 +1,3 @@
-@import '~bootstrap/dist/css/bootstrap.min.css';
-
 /* Product */
 $iris-purple: #534DC8;
 $iris-purple-hover: #727FE0;

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -4,13 +4,22 @@ import Footer from './Footer'
 import withSizes from 'react-sizes'
 
 class Layout extends React.Component {
+  componentDidMount() {
+    this.setState({ width: window.innerWidth })
+  }
+
   render() {
     const { children, width } = this.props
+
+    if (!width && !this.state) {
+      console.log('BOTH STATE AND WIDTH ARE NULL')
+      return null
+    }
 
     return (
       <div>
         {children}
-        <Footer width={width} />
+        <Footer width={width || this.state.width} />
       </div>
     )
   }


### PR DESCRIPTION
It's a weird fix. I still can't explain this, since I've logged `width` in `render` and have confirmed that it's never falsy.

Nevertheless, the fix was to assume that it could be falsy.

## What was probably happening
Initial render was probably using the width Gatsby computed at build time, which would be a falsy value since there is no `window` at build time.

## The Fix
We add a fallback check to get the current window.innerWidth. If the width from react-sizes is falsy, we fallback to `window.innerWidth`.